### PR TITLE
Change date format to year, days

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discordmemories",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discordmemories",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "name": "discordmemories",
   "description": "A simple bot to look at past memories",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "main": "index.js",
   "engines": {
     "node": "^16.14.2",

--- a/src/utils/calcDate.js
+++ b/src/utils/calcDate.js
@@ -1,14 +1,26 @@
 
 module.exports = {
     calcDate(date) {
-        let diffDate = new Date(new Date().getTime() - date);
-        let years = diffDate.toISOString().slice(0, 4) - 1970;
+        let difference = dateDiffInDays(new Date(date), new Date());
+        let years = Math.floor(difference / 365.25);
+        let days = Math.floor(difference % 365.25); 
 
         if (years > 0) {
-            return years + " Years " + diffDate.getMonth() + " Months " 
-            + (diffDate.getDate() - 1) + " Days ago!";
+            return years + " Years " + days + " Days ago!";
         } else {
-            return diffDate.getMonth() + " Months " + (diffDate.getDate() - 1) + " Days ago!";
+            return days + " Days ago!";
         }
     }
 }
+
+// Source: https://stackoverflow.com/a/15289883
+function dateDiffInDays(a, b) {
+    const _MS_PER_DAY = 1000 * 60 * 60 * 24;
+    // Discard the time and time-zone information.
+    const utc1 = Date.UTC(a.getFullYear(), a.getMonth(), a.getDate());
+    const utc2 = Date.UTC(b.getFullYear(), b.getMonth(), b.getDate());
+  
+    return Math.floor((utc2 - utc1) / _MS_PER_DAY);
+  }
+  
+  


### PR DESCRIPTION
Signed-off-by: lennysgarage <lennysgarage1@gmail.com>

Change date format from year, months, days to:
`years, days` or just `days`
